### PR TITLE
Update junos.py

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -45,24 +45,24 @@ def init(opts):
     Resource class
     '''
     log.debug('Opening connection to junos')
-        args = {"user"      : opts['proxy']['username'],
-                "host"      : opts['proxy']['host'],
-                "password"  : opts['proxy']['passwd']
-               }
-        optional_args= ['gather_facts', 
-                        'mode',
-                        'baud',
-                        'attempts',
-                        'auto_probe',
-                        'ssh_private_key',
-                        'ssh_config',
-                        'normalize'
-                       ]
-        for arg in optional_args:
-            if arg in opts['proxy'].keys():
-                args[arg] = opts['proxy'][arg]
+    args = {"user"      : opts['proxy']['username'],
+            "host"      : opts['proxy']['host'],
+            "password"  : opts['proxy']['passwd']
+           }
+    optional_args= ['gather_facts', 
+                    'mode',
+                    'baud',
+                    'attempts',
+                    'auto_probe',
+                    'ssh_private_key',
+                    'ssh_config',
+                    'normalize'
+                   ]
+    for arg in optional_args:
+        if arg in opts['proxy'].keys():
+            args[arg] = opts['proxy'][arg]
 
-        thisproxy['conn'] = jnpr.junos.Device(**args)
+    thisproxy['conn'] = jnpr.junos.Device(**args)
     thisproxy['conn'].open()
     thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
     thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -49,7 +49,8 @@ def init(opts):
             "host"      : opts['proxy']['host'],
             "password"  : opts['proxy']['passwd']
            }
-    optional_args= ['gather_facts', 
+    optional_args= ['port',
+                    'gather_facts', 
                     'mode',
                     'baud',
                     'attempts',

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -45,9 +45,24 @@ def init(opts):
     Resource class
     '''
     log.debug('Opening connection to junos')
-    thisproxy['conn'] = jnpr.junos.Device(user=opts['proxy']['username'],
-                                          host=opts['proxy']['host'],
-                                          password=opts['proxy']['passwd'])
+        args = {"user"      : opts['proxy']['username'],
+                "host"      : opts['proxy']['host'],
+                "password"  : opts['proxy']['passwd']
+               }
+        optional_args= ['gather_facts', 
+                        'mode',
+                        'baud',
+                        'attempts',
+                        'auto_probe',
+                        'ssh_private_key',
+                        'ssh_config',
+                        'normalize'
+                       ]
+        for arg in optional_args:
+            if arg in opts['proxy'].keys():
+                args[arg] = opts['proxy'][arg]
+
+        thisproxy['conn'] = jnpr.junos.Device(**args)
     thisproxy['conn'].open()
     thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
     thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -45,11 +45,10 @@ def init(opts):
     Resource class
     '''
     log.debug('Opening connection to junos')
-    args = {"user"      : opts['proxy']['username'],
-            "host"      : opts['proxy']['host'],
-            "password"  : opts['proxy']['passwd']
-           }
-    optional_args= ['port',
+    args = { "host" : opts['proxy']['host'] }
+    optional_args= ['user',
+                    'password'
+                    'port',
                     'gather_facts', 
                     'mode',
                     'baud',


### PR DESCRIPTION
### What does this PR do?
Allows optional arguments to be used by salt proxy minion for Junos.

### What issues does this PR fix or reference?
Inability to connect to arbitrary Netconf destination port on Junos devices

### Previous Behavior
Proxy minion connection to a device with netconf blocked on port 830 would timeout and continue retrying infinitely until killed by user.

### New Behavior
Proxy minion connection to a device with netconf blocked on port 830 succeeds.  

### Tests written?

No
Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
